### PR TITLE
Fixed deprecated upload-artifact action

### DIFF
--- a/.github/workflows/defillama_daily_pipeline.yml
+++ b/.github/workflows/defillama_daily_pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           echo "✅ Pipeline completed at $(date)"
 
       - name: Upload logs and metrics
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pipeline-logs-${{ github.run_number }}
           path: |


### PR DESCRIPTION
**Is this linked to an existing issue**

quick fix to re-run github action testing